### PR TITLE
migrate to Zig 0.16

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,9 +14,9 @@ pub fn build(b: *Builder) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = if (option_libc) true else null,
         }),
     });
-    if (option_libc) exe.linkLibC();
     b.installArtifact(exe);
 
     const exe_tinyhost = b.addExecutable(.{
@@ -25,9 +25,9 @@ pub fn build(b: *Builder) void {
             .root_source_file = b.path("src/main_tinyhost.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = if (option_libc) true else null,
         }),
     });
-    if (option_libc) exe.linkLibC();
     b.installArtifact(exe_tinyhost);
 
     _ = b.addModule("zigdig", .{ .root_source_file = b.path("src/lib.zig") });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zigdig,
     .version = "0.1.1",
     .fingerprint = 0x19f126b179bd5a9,
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/src/cidr.zig
+++ b/src/cidr.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
 const mem = std.mem;
 const fmt = std.fmt;
 
@@ -33,7 +33,7 @@ pub const CidrRange = struct {
         const prefix_len = std.fmt.parseInt(u8, prefix_str, 10) catch return error.InvalidPrefixLength;
 
         // Try parsing as IPv4
-        const maybe_ipv4 = net.Address.parseIp4(addr_str, 0) catch |err| switch (err) {
+        const maybe_ipv4 = net.Ip4Address.parse(addr_str, 0) catch |err| switch (err) {
             else => null,
         };
         if (maybe_ipv4) |ipv4| {
@@ -47,13 +47,12 @@ pub const CidrRange = struct {
             };
 
             // implementation wise all addresses get mapped to ipv6 internally
-            const bytes = std.mem.toBytes(ipv4.in.sa.addr);
             result.first_address[10] = 0xff;
             result.first_address[11] = 0xff;
-            result.first_address[12] = bytes[0];
-            result.first_address[13] = bytes[1];
-            result.first_address[14] = bytes[2];
-            result.first_address[15] = bytes[3];
+            result.first_address[12] = ipv4.bytes[0];
+            result.first_address[13] = ipv4.bytes[1];
+            result.first_address[14] = ipv4.bytes[2];
+            result.first_address[15] = ipv4.bytes[3];
 
             // Clear host portion
             const host_bits = 32 - prefix_len;
@@ -70,7 +69,7 @@ pub const CidrRange = struct {
             return result;
         }
 
-        const maybe_ipv6: ?std.net.Address = std.net.Address.parseIp6(addr_str, 0) catch |err| switch (err) {
+        const maybe_ipv6: ?net.Ip6Address = net.Ip6Address.parse(addr_str, 0) catch |err| switch (err) {
             else => null,
         };
         if (maybe_ipv6) |ipv6| {
@@ -78,7 +77,7 @@ pub const CidrRange = struct {
 
             var result = CidrRange{
                 .version = .v6,
-                .first_address = ipv6.in6.sa.addr,
+                .first_address = ipv6.bytes,
                 .prefix_len = prefix_len,
             };
 
@@ -102,24 +101,18 @@ pub const CidrRange = struct {
     }
 
     /// Check if an IP address is within this CIDR range
-    pub fn contains(self: Self, addr: std.net.Address) !bool {
-        var data: [16]u8 = switch (addr.any.family) {
-            std.posix.AF.INET => blk: {
-                const raw_in_bytes = std.mem.toBytes(addr.in.sa.addr);
-
+    pub fn contains(self: Self, addr: std.Io.net.IpAddress) !bool {
+        var data: [16]u8 = switch (addr) {
+            .ip4 => |ip4| blk: {
                 var result: [16]u8 = [_]u8{0} ** 16;
                 // Set the IPv4-mapped IPv6 prefix (::ffff:)
                 result[10] = 0xff;
                 result[11] = 0xff;
                 // Copy the IPv4 address bytes
-                @memcpy(result[12..16], &raw_in_bytes);
-
+                @memcpy(result[12..16], &ip4.bytes);
                 break :blk result;
             },
-            std.posix.AF.INET6 => blk: {
-                break :blk addr.in6.sa.addr;
-            },
-            else => return CidrParseError.InvalidAddress,
+            .ip6 => |ip6| ip6.bytes,
         };
 
         const full_bytes = self.prefix_len / 8;
@@ -160,7 +153,7 @@ pub const CidrRange = struct {
                 });
             },
             .v6 => {
-                const addr = std.net.Ip6Address.init(self.first_address, 0, 0, 0);
+                const addr = net.Ip6Address{ .bytes = self.first_address, .port = 0 };
                 try writer.print("{f}/{d}", .{ addr, self.prefix_len });
             },
         }
@@ -364,15 +357,14 @@ test "Boundary prefix lengths" {
 }
 
 fn ip4ToBytes(strAddr: []const u8, port: u16) [16]u8 {
-    const ipv4 = std.net.Address.parseIp4(strAddr, port) catch unreachable;
-    const addr = std.mem.toBytes(ipv4.in.sa.addr);
+    const ipv4 = net.Ip4Address.parse(strAddr, port) catch unreachable;
 
     var result: [16]u8 = [_]u8{0} ** 16;
     // Set the IPv4-mapped IPv6 prefix (::ffff:)
     result[10] = 0xff;
     result[11] = 0xff;
     // Copy the IPv4 address bytes
-    @memcpy(result[12..16], &addr);
+    @memcpy(result[12..16], &ipv4.bytes);
     return result;
 }
 
@@ -381,14 +373,14 @@ test "IPv4 contains basic tests" {
     const cidr = try CidrRange.parse("192.168.1.0/24");
 
     // These should be in the range
-    try testing.expect(try cidr.contains(std.net.Address.parseIp4("192.168.1.0", 0) catch unreachable));
-    try testing.expect(try cidr.contains(std.net.Address.parseIp4("192.168.1.1", 0) catch unreachable));
-    try testing.expect(try cidr.contains(std.net.Address.parseIp4("192.168.1.255", 0) catch unreachable));
+    try testing.expect(try cidr.contains(net.IpAddress.parseIp4("192.168.1.0", 0) catch unreachable));
+    try testing.expect(try cidr.contains(net.IpAddress.parseIp4("192.168.1.1", 0) catch unreachable));
+    try testing.expect(try cidr.contains(net.IpAddress.parseIp4("192.168.1.255", 0) catch unreachable));
 
     // These should not be in the range
-    try testing.expect(!try cidr.contains(std.net.Address.parseIp4("192.168.0.255", 0) catch unreachable));
-    try testing.expect(!try cidr.contains(std.net.Address.parseIp4("192.168.2.0", 0) catch unreachable));
-    try testing.expect(!try cidr.contains(std.net.Address.parseIp4("192.169.1.1", 0) catch unreachable));
+    try testing.expect(!try cidr.contains(net.IpAddress.parseIp4("192.168.0.255", 0) catch unreachable));
+    try testing.expect(!try cidr.contains(net.IpAddress.parseIp4("192.168.2.0", 0) catch unreachable));
+    try testing.expect(!try cidr.contains(net.IpAddress.parseIp4("192.169.1.1", 0) catch unreachable));
 }
 
 test "IPv6 contains basic tests" {
@@ -396,43 +388,43 @@ test "IPv6 contains basic tests" {
     const cidr = try CidrRange.parse("2001:db8::/64");
 
     // These should be in the range
-    try testing.expect(try cidr.contains(try net.Address.parseIp6("2001:db8::", 0)));
-    try testing.expect(try cidr.contains(try net.Address.parseIp6("2001:db8::1", 0)));
-    try testing.expect(try cidr.contains(try net.Address.parseIp6("2001:db8::ffff", 0)));
+    try testing.expect(try cidr.contains(try net.IpAddress.parseIp6("2001:db8::", 0)));
+    try testing.expect(try cidr.contains(try net.IpAddress.parseIp6("2001:db8::1", 0)));
+    try testing.expect(try cidr.contains(try net.IpAddress.parseIp6("2001:db8::ffff", 0)));
 
     // These should not be in the range
-    try testing.expect(!try cidr.contains(try net.Address.parseIp6("2001:db9::", 0)));
-    try testing.expect(!try cidr.contains(try net.Address.parseIp6("2001:db8:1::", 0)));
-    try testing.expect(!try cidr.contains(try net.Address.parseIp6("2002:db8::", 0)));
+    try testing.expect(!try cidr.contains(try net.IpAddress.parseIp6("2001:db9::", 0)));
+    try testing.expect(!try cidr.contains(try net.IpAddress.parseIp6("2001:db8:1::", 0)));
+    try testing.expect(!try cidr.contains(try net.IpAddress.parseIp6("2002:db8::", 0)));
 }
 
 test "contains edge prefix lengths" {
     // Test /0 (entire address space)
     {
         const cidr_v4 = try CidrRange.parse("0.0.0.0/0");
-        try testing.expect(try cidr_v4.contains(try std.net.Address.parseIp4("0.0.0.0", 0)));
-        try testing.expect(try cidr_v4.contains(try std.net.Address.parseIp4("255.255.255.255", 0)));
-        try testing.expect(try cidr_v4.contains(try std.net.Address.parseIp4("192.168.1.1", 0)));
+        try testing.expect(try cidr_v4.contains(try net.IpAddress.parseIp4("0.0.0.0", 0)));
+        try testing.expect(try cidr_v4.contains(try net.IpAddress.parseIp4("255.255.255.255", 0)));
+        try testing.expect(try cidr_v4.contains(try net.IpAddress.parseIp4("192.168.1.1", 0)));
     }
 
     {
         const cidr_v6 = try CidrRange.parse("::/0");
-        try testing.expect(try cidr_v6.contains(try net.Address.parseIp6("::", 0)));
-        try testing.expect(try cidr_v6.contains(try net.Address.parseIp6("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 0)));
-        try testing.expect(try cidr_v6.contains(try net.Address.parseIp6("2001:db8::1", 0)));
+        try testing.expect(try cidr_v6.contains(try net.IpAddress.parseIp6("::", 0)));
+        try testing.expect(try cidr_v6.contains(try net.IpAddress.parseIp6("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 0)));
+        try testing.expect(try cidr_v6.contains(try net.IpAddress.parseIp6("2001:db8::1", 0)));
     }
 
     // Test single address (/32 for IPv4, /128 for IPv6)
     {
         const cidr_v4 = try CidrRange.parse("192.168.1.1/32");
-        try testing.expect(try cidr_v4.contains(try std.net.Address.parseIp4("192.168.1.1", 0)));
-        try testing.expect(!try cidr_v4.contains(try std.net.Address.parseIp4("192.168.1.2", 0)));
+        try testing.expect(try cidr_v4.contains(try net.IpAddress.parseIp4("192.168.1.1", 0)));
+        try testing.expect(!try cidr_v4.contains(try net.IpAddress.parseIp4("192.168.1.2", 0)));
     }
 
     {
         const cidr_v6 = try CidrRange.parse("2001:db8::1/128");
-        try testing.expect(try cidr_v6.contains(try net.Address.parseIp6("2001:db8::1", 0)));
-        try testing.expect(!try cidr_v6.contains(try net.Address.parseIp6("2001:db8::2", 0)));
+        try testing.expect(try cidr_v6.contains(try net.IpAddress.parseIp6("2001:db8::1", 0)));
+        try testing.expect(!try cidr_v6.contains(try net.IpAddress.parseIp6("2001:db8::2", 0)));
     }
 }
 
@@ -440,17 +432,17 @@ test "contains non-aligned prefix lengths" {
     // Test IPv4 /23 (two /24 networks)
     {
         const cidr = try CidrRange.parse("192.168.0.0/23");
-        try testing.expect(try cidr.contains(try std.net.Address.parseIp4("192.168.0.1", 0)));
-        try testing.expect(try cidr.contains(try std.net.Address.parseIp4("192.168.1.1", 0)));
-        try testing.expect(!try cidr.contains(try std.net.Address.parseIp4("192.168.2.1", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp4("192.168.0.1", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp4("192.168.1.1", 0)));
+        try testing.expect(!try cidr.contains(try net.IpAddress.parseIp4("192.168.2.1", 0)));
     }
 
     // Test IPv6 /63 (two /64 networks)
     {
         const cidr = try CidrRange.parse("2001:db8::/63");
-        try testing.expect(try cidr.contains(try net.Address.parseIp6("2001:db8::", 0)));
-        try testing.expect(try cidr.contains(try net.Address.parseIp6("2001:db8:0:1::", 0)));
-        try testing.expect(!try cidr.contains(try net.Address.parseIp6("2001:db8:0:2::", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp6("2001:db8::", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp6("2001:db8:0:1::", 0)));
+        try testing.expect(!try cidr.contains(try net.IpAddress.parseIp6("2001:db8:0:2::", 0)));
     }
 }
 
@@ -458,16 +450,16 @@ test "contains byte boundary edge cases" {
     // Test IPv4 /16 (byte boundary)
     {
         const cidr = try CidrRange.parse("192.168.0.0/16");
-        try testing.expect(try cidr.contains(try std.net.Address.parseIp4("192.168.0.0", 0)));
-        try testing.expect(try cidr.contains(try std.net.Address.parseIp4("192.168.255.255", 0)));
-        try testing.expect(!try cidr.contains(try std.net.Address.parseIp4("192.169.0.0", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp4("192.168.0.0", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp4("192.168.255.255", 0)));
+        try testing.expect(!try cidr.contains(try net.IpAddress.parseIp4("192.169.0.0", 0)));
     }
 
     // Test IPv6 /48 (byte boundary)
     {
         const cidr = try CidrRange.parse("2001:db8:1100::/48");
-        try testing.expect(try cidr.contains(try net.Address.parseIp6("2001:db8:1100::", 0)));
-        try testing.expect(try cidr.contains(try net.Address.parseIp6("2001:db8:1100:ffff::", 0)));
-        try testing.expect(!try cidr.contains(try net.Address.parseIp6("2001:db8:1101::", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp6("2001:db8:1100::", 0)));
+        try testing.expect(try cidr.contains(try net.IpAddress.parseIp6("2001:db8:1100:ffff::", 0)));
+        try testing.expect(!try cidr.contains(try net.IpAddress.parseIp6("2001:db8:1101::", 0)));
     }
 }

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -72,12 +72,12 @@ pub const ResourceType = enum(u16) {
 
     pub fn readFrom(reader: *std.Io.Reader) !Self {
         const resource_type_int = try reader.takeInt(u16, .big);
-        return std.meta.intToEnum(Self, resource_type_int) catch |err| {
+        return std.enums.fromInt(Self, resource_type_int) orelse {
             logger.err(
-                "unknown resource type {d}, got {s}",
-                .{ resource_type_int, @errorName(err) },
+                "unknown resource type {d}",
+                .{resource_type_int},
             );
-            return err;
+            return error.InvalidEnumTag;
         };
     }
 
@@ -101,12 +101,12 @@ pub const ResourceClass = enum(u16) {
 
     pub fn readFrom(reader: *std.Io.Reader) !@This() {
         const resource_class_int = try reader.takeInt(u16, .big);
-        return std.meta.intToEnum(@This(), resource_class_int) catch |err| {
+        return std.enums.fromInt(@This(), resource_class_int) orelse {
             logger.err(
-                "unknown resource class {d}, got {s}",
-                .{ resource_class_int, @errorName(err) },
+                "unknown resource class {d}",
+                .{resource_class_int},
             );
-            return err;
+            return error.InvalidEnumTag;
         };
     }
 

--- a/src/helpers.zig
+++ b/src/helpers.zig
@@ -400,8 +400,8 @@ pub fn receiveTrustedAddresses(
 }
 
 fn fetchTrustedAddresses(
-    allocator: std.mem.Allocator,
     io: std.Io,
+    allocator: std.mem.Allocator,
     name: dns.Name,
     qtype: dns.ResourceType,
 ) ![]std.Io.net.IpAddress {
@@ -435,7 +435,7 @@ fn fetchTrustedAddresses(
 }
 
 // implementation taken from std.net address resolution
-fn lookupHosts(allocator: std.mem.Allocator, io: std.Io, addrs: *std.ArrayList(std.Io.net.IpAddress), port: u16, name: []const u8) !void {
+fn lookupHosts(io: std.Io, allocator: std.mem.Allocator, addrs: *std.ArrayList(std.Io.net.IpAddress), port: u16, name: []const u8) !void {
     const file = std.Io.Dir.openFileAbsolute(io, "/etc/hosts", .{}) catch |err| switch (err) {
         error.FileNotFound,
         error.NotDir,
@@ -495,15 +495,15 @@ pub fn getAddressList(io: std.Io, incoming_name: []const u8, port: u16, allocato
         try final_list.append(allocator, .{ .ip6 = .{ .bytes = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, .port = port } });
     } else {
         if (builtin.os.tag == .linux or builtin.os.tag == .macos) {
-            try lookupHosts(allocator, io, &final_list, port, incoming_name);
+            try lookupHosts(io, allocator, &final_list, port, incoming_name);
 
             if (final_list.items.len == 0) {
                 // if that didn't work, go to dns server
-                const addrs_v4 = try fetchTrustedAddresses(allocator, io, name, .A);
+                const addrs_v4 = try fetchTrustedAddresses(io, allocator, name, .A);
                 defer allocator.free(addrs_v4);
                 for (addrs_v4) |addr| try final_list.append(allocator, addr);
 
-                const addrs_v6 = try fetchTrustedAddresses(allocator, io, name, .AAAA);
+                const addrs_v6 = try fetchTrustedAddresses(io, allocator, name, .AAAA);
                 defer allocator.free(addrs_v6);
                 for (addrs_v6) |addr| try final_list.append(allocator, addr);
             }

--- a/src/helpers.zig
+++ b/src/helpers.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const ws2_32 = std.os.windows.ws2_32;
 const dns = @import("lib.zig");
 
 const CidrRange = @import("cidr.zig").CidrRange;
@@ -102,8 +101,10 @@ pub fn printAsZoneFile(
 }
 
 /// Generate a random header ID to use in a query.
-pub fn randomHeaderId() u16 {
-    const seed = @as(u64, @truncate(@as(u128, @bitCast(std.time.nanoTimestamp()))));
+pub fn randomHeaderId(io: std.Io) u16 {
+    var seed_buf: [8]u8 = undefined;
+    io.random(&seed_buf);
+    const seed = std.mem.readInt(u64, &seed_buf, .little);
     var r = std.Random.DefaultPrng.init(seed);
     return r.random().int(u16);
 }
@@ -111,45 +112,27 @@ pub fn randomHeaderId() u16 {
 /// High level wrapper around a single UDP connection to send and receive
 /// DNS packets.
 pub const DNSConnection = struct {
-    address: std.net.Address,
-    socket: std.net.Stream,
+    address: std.Io.net.IpAddress,
+    socket: std.Io.net.Socket,
+    io: std.Io,
 
     const Self = @This();
 
     pub fn close(self: Self) void {
-        self.socket.close();
+        self.socket.close(self.io);
     }
 
     pub fn sendPacket(self: Self, packet: dns.Packet) !void {
-        // Stream won't use sendto() when its UDP, so serialize it into
-        // a buffer, and then send that
         var buffer: [1024]u8 = undefined;
 
-        var writer = std.io.Writer.fixed(&buffer);
+        var writer = std.Io.Writer.fixed(&buffer);
         try packet.writeTo(&writer);
 
         const result = buffer[0..writer.end];
-        const dest_len: u32 = switch (self.address.any.family) {
-            std.posix.AF.INET => @sizeOf(std.posix.sockaddr.in),
-            std.posix.AF.INET6 => @sizeOf(std.posix.sockaddr.in6),
-            else => unreachable,
-        };
-
-        _ = try std.posix.sendto(
-            self.socket.handle,
-            result,
-            0,
-            &self.address.any,
-            dest_len,
-        );
+        try self.socket.send(self.io, &self.address, result);
     }
 
     /// Deserializes and allocates an *entire* DNS packet.
-    ///
-    /// This function is not encouraged if you only wish to get A/AAAA
-    /// records for a domain name through the system DNS resolver, as this
-    /// allocates all the data of the packet. Use `receiveTrustedAddresses`
-    /// for such.
     pub fn receiveFullPacket(
         self: Self,
         packet_allocator: std.mem.Allocator,
@@ -158,8 +141,9 @@ pub const DNSConnection = struct {
         options: ParseFullPacketOptions,
     ) !dns.IncomingPacket {
         var packet_buffer: [max_incoming_message_size]u8 = undefined;
-        const read_bytes = try self.socket.read(&packet_buffer);
-        const packet_bytes = packet_buffer[0..read_bytes];
+        const msg = try self.socket.receive(self.io, &packet_buffer);
+        const read_bytes = msg.data.len;
+        const packet_bytes = msg.data;
         logger.debug("read {d} bytes", .{read_bytes});
 
         var stream = std.Io.Reader.fixed(packet_bytes);
@@ -170,8 +154,6 @@ pub const DNSConnection = struct {
 pub const ParseFullPacketOptions = struct {
     /// Use this NamePool to let deserialization of names outlive the call
     /// to parseFullPacket.
-    ///
-    /// Useful if you need to parse RDATA sections after parseFullPacket.
     name_pool: ?*dns.NamePool = null,
 };
 
@@ -194,22 +176,22 @@ pub fn parseFullPacket(
     var builtin_name_pool = dns.NamePool.init(allocator);
     defer builtin_name_pool.deinit();
 
-    var name_pool = if (parse_full_packet_options.name_pool) |name_pool|
-        name_pool
+    var name_pool = if (parse_full_packet_options.name_pool) |np|
+        np
     else
         &builtin_name_pool;
 
-    var questions = std.array_list.Managed(dns.Question).init(allocator);
-    defer questions.deinit();
+    var questions = std.ArrayList(dns.Question).empty;
+    defer questions.deinit(allocator);
 
-    var answers = std.array_list.Managed(dns.Resource).init(allocator);
-    defer answers.deinit();
+    var answers = std.ArrayList(dns.Resource).empty;
+    defer answers.deinit(allocator);
 
-    var nameservers = std.array_list.Managed(dns.Resource).init(allocator);
-    defer nameservers.deinit();
+    var nameservers = std.ArrayList(dns.Resource).empty;
+    defer nameservers.deinit(allocator);
 
-    var additionals = std.array_list.Managed(dns.Resource).init(allocator);
-    defer additionals.deinit();
+    var additionals = std.ArrayList(dns.Resource).empty;
+    defer additionals.deinit(allocator);
 
     while (try parser.next()) |part| {
         switch (part) {
@@ -217,22 +199,21 @@ pub fn parseFullPacket(
             .question => |question_with_raw_names| {
                 const question =
                     try name_pool.transmuteResource(question_with_raw_names);
-                try questions.append(question);
+                try questions.append(allocator, question);
             },
-            .end_question => packet.questions = try questions.toOwnedSlice(),
+            .end_question => packet.questions = try questions.toOwnedSlice(allocator),
             .answer, .nameserver, .additional => |raw_resource| {
-                // since we give it an allocator, we don't receive rdata frames
                 const resource = try name_pool.transmuteResource(raw_resource);
                 try (switch (part) {
-                    .answer => answers,
-                    .nameserver => nameservers,
-                    .additional => additionals,
+                    .answer => &answers,
+                    .nameserver => &nameservers,
+                    .additional => &additionals,
                     else => unreachable,
-                }).append(resource);
+                }).append(allocator, resource);
             },
-            .end_answer => packet.answers = try answers.toOwnedSlice(),
-            .end_nameserver => packet.nameservers = try nameservers.toOwnedSlice(),
-            .end_additional => packet.additionals = try additionals.toOwnedSlice(),
+            .end_answer => packet.answers = try answers.toOwnedSlice(allocator),
+            .end_nameserver => packet.nameservers = try nameservers.toOwnedSlice(allocator),
+            .end_additional => packet.additionals = try additionals.toOwnedSlice(allocator),
             .answer_rdata, .nameserver_rdata, .additional_rdata => unreachable,
         }
     }
@@ -243,59 +224,43 @@ pub fn parseFullPacket(
 const logger = std.log.scoped(.dns_helpers);
 
 /// Open a socket to the DNS resolver specified in input parameter
-pub fn connectToResolver(address: []const u8, port: ?u16) !DNSConnection {
-    const addr = blk: {
-        if (builtin.os.tag == .windows) {
-            // it is recommended to use `resolveIp`, but windows currently does
-            // not support resolving ipv6 addresses. there is a PR for the
-            // stdlib here: https://github.com/ziglang/zig/pull/22555 as soon
-            // as that is merged, this can be removed. till then, as
-            // `resolveIp` is only recommended in order to handle ipv6 link
-            // local addresses, we can use `parseIp`, as the use case
-            // `resolveIp` is intended for doesnt work.
-            break :blk try std.net.Address.parseIp(address, port orelse 53);
-        } else {
-            break :blk try std.net.Address.resolveIp(address, port orelse 53);
-        }
+pub fn connectToResolver(io: std.Io, address: []const u8, port: ?u16) !DNSConnection {
+    const addr = try std.Io.net.IpAddress.parse(address, port orelse 53);
+
+    // Bind to any local address to create a UDP socket
+    const local_addr: std.Io.net.IpAddress = switch (addr) {
+        .ip4 => .{ .ip4 = .{ .bytes = .{ 0, 0, 0, 0 }, .port = 0 } },
+        .ip6 => .{ .ip6 = .{ .bytes = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .port = 0 } },
     };
 
-    const flags: u32 = std.posix.SOCK.DGRAM;
-    const fd = try std.posix.socket(addr.any.family, flags, std.posix.IPPROTO.UDP);
+    const socket = try std.Io.net.IpAddress.bind(&local_addr, io, .{ .mode = .dgram });
 
     return DNSConnection{
         .address = addr,
-        .socket = std.net.Stream{ .handle = fd },
+        .socket = socket,
+        .io = io,
     };
 }
 
 /// Open a socket to a random DNS resolver declared in the systems'
 /// "/etc/resolv.conf" file.
-pub fn connectToSystemResolver() !DNSConnection {
-    //@compileLog("should not be reached");
+pub fn connectToSystemResolver(io: std.Io) !DNSConnection {
     var out_buffer: [256]u8 = undefined;
 
-    if (builtin.os.tag != .linux) @compileError("connectToSystemResolver not supported on this target");
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos)
+        @compileError("connectToSystemResolver not supported on this target");
 
-    const nameserver_address_string = (try randomNameserver(&out_buffer)).?;
+    const nameserver_address_string = (try randomNameserver(io, &out_buffer)).?;
 
-    return connectToResolver(nameserver_address_string, null);
+    return connectToResolver(io, nameserver_address_string, null);
 }
 
-pub fn randomNameserver(output_buffer: []u8) !?[]const u8 {
-    var file = try std.fs.cwd().openFile(
-        "/etc/resolv.conf",
-        .{ .mode = .read_only },
-    );
-    defer file.close();
-
-    // iterate through all lines to find the amount of nameservers, then select
-    // a random one, then read AGAIN so that we can return it.
-    //
-    // this doesn't need any allocator or lists or whatever. just the
-    // output buffer
+pub fn randomNameserver(io: std.Io, output_buffer: []u8) !?[]const u8 {
+    var file = try std.Io.Dir.cwd().openFile(io, "/etc/resolv.conf", .{ .mode = .read_only });
+    defer file.close(io);
 
     var line_buffer: [1024]u8 = undefined;
-    var reader = file.reader(&line_buffer);
+    var reader = file.reader(io, &line_buffer);
     try reader.seekTo(0);
 
     var nameserver_amount: usize = 0;
@@ -311,7 +276,9 @@ pub fn randomNameserver(output_buffer: []u8) !?[]const u8 {
         }
     }
 
-    const seed = @as(u64, @truncate(@as(u128, @bitCast(std.time.nanoTimestamp()))));
+    var seed_buf: [8]u8 = undefined;
+    io.random(&seed_buf);
+    const seed = std.mem.readInt(u64, &seed_buf, .little);
     var r = std.Random.DefaultPrng.init(seed);
     const selected = r.random().uintLessThan(usize, nameserver_amount);
 
@@ -343,13 +310,13 @@ pub fn randomNameserver(output_buffer: []u8) !?[]const u8 {
 
 const AddressList = struct {
     allocator: std.mem.Allocator,
-    addrs: []std.net.Address,
+    addrs: []std.Io.net.IpAddress,
     pub fn deinit(self: @This()) void {
         self.allocator.free(self.addrs);
     }
 
-    fn fromList(allocator: std.mem.Allocator, addrs: *std.array_list.Managed(std.net.Address)) !AddressList {
-        return AddressList{ .allocator = allocator, .addrs = try addrs.toOwnedSlice() };
+    fn fromList(allocator: std.mem.Allocator, addrs: *std.ArrayList(std.Io.net.IpAddress)) !AddressList {
+        return AddressList{ .allocator = allocator, .addrs = try addrs.toOwnedSlice(allocator) };
     }
 };
 
@@ -359,30 +326,25 @@ const ReceiveTrustedAddressesOptions = struct {
 };
 
 /// This is an optimized deserializer that is only interested in A and AAAA
-/// answers, returning a list of std.net.Address.
-///
-/// This function trusts the DNS connection to be returning answers related
-/// to the given domain sent through DNSConnection.sendPacket.
-///
-/// This, however, does not allocate the packet. It is very memory efficient
-/// in that regard.
+/// answers, returning a list of std.Io.net.IpAddress.
 pub fn receiveTrustedAddresses(
     allocator: std.mem.Allocator,
     connection: *const DNSConnection,
     /// Options to receive message and deserialize it
     comptime options: ReceiveTrustedAddressesOptions,
-) ![]std.net.Address {
+) ![]std.Io.net.IpAddress {
     var packet_buffer: [options.max_incoming_message_size]u8 = undefined;
-    const read_bytes = try connection.socket.read(&packet_buffer);
-    const packet_bytes = packet_buffer[0..read_bytes];
+    const msg = try connection.socket.receive(connection.io, &packet_buffer);
+    const read_bytes = msg.data.len;
+    const packet_bytes = msg.data;
     logger.debug("read {d} bytes", .{read_bytes});
 
     var reader = std.Io.Reader.fixed(packet_bytes);
 
     var parser = dns.Parser.init(&reader, .{});
 
-    var addrs = std.array_list.Managed(std.net.Address).init(allocator);
-    errdefer addrs.deinit();
+    var addrs = std.ArrayList(std.Io.net.IpAddress).empty;
+    errdefer addrs.deinit(allocator);
 
     var current_resource: ?dns.Resource = null;
 
@@ -398,7 +360,7 @@ pub fn receiveTrustedAddresses(
 
                 switch (header.response_code) {
                     .NoError => {},
-                    .FormatError => return error.ServerFormatError, // bug in implementation caught by server?
+                    .FormatError => return error.ServerFormatError,
                     .ServerFailure => return error.ServerFailure,
                     .NameError => return error.ServerNameError,
                     .NotImplemented => return error.ServerNotImplemented,
@@ -411,16 +373,16 @@ pub fn receiveTrustedAddresses(
 
             .answer_rdata => |rdata| {
                 defer current_resource = null;
-                const maybe_addr = switch (current_resource.?.typ) {
+                const maybe_addr: ?std.Io.net.IpAddress = switch (current_resource.?.typ) {
                     .A => blk: {
                         var ip4addr: [4]u8 = undefined;
                         _ = try reader.readSliceAll(&ip4addr);
-                        break :blk std.net.Address.initIp4(ip4addr, 0);
+                        break :blk .{ .ip4 = .{ .bytes = ip4addr, .port = 0 } };
                     },
                     .AAAA => blk: {
                         var ip6_addr: [16]u8 = undefined;
                         _ = try reader.readSliceAll(&ip6_addr);
-                        break :blk std.net.Address.initIp6(ip6_addr, 0, 0, 0);
+                        break :blk .{ .ip6 = .{ .bytes = ip6_addr, .port = 0 } };
                     },
                     else => blk: {
                         reader.toss(rdata.size);
@@ -428,20 +390,21 @@ pub fn receiveTrustedAddresses(
                     },
                 };
 
-                if (maybe_addr) |addr| try addrs.append(addr);
+                if (maybe_addr) |addr| try addrs.append(allocator, addr);
             },
             else => {},
         }
     }
 
-    return try addrs.toOwnedSlice();
+    return try addrs.toOwnedSlice(allocator);
 }
 
 fn fetchTrustedAddresses(
     allocator: std.mem.Allocator,
+    io: std.Io,
     name: dns.Name,
     qtype: dns.ResourceType,
-) ![]std.net.Address {
+) ![]std.Io.net.IpAddress {
     var questions = [_]dns.Question{
         .{
             .name = name,
@@ -452,7 +415,7 @@ fn fetchTrustedAddresses(
 
     const packet = dns.Packet{
         .header = .{
-            .id = dns.helpers.randomHeaderId(),
+            .id = dns.helpers.randomHeaderId(io),
             .is_response = false,
             .wanted_recursion = true,
             .question_length = 1,
@@ -463,8 +426,7 @@ fn fetchTrustedAddresses(
         .additionals = &[_]dns.Resource{},
     };
 
-    //@compileLog("from fetchtrustedaddresses");
-    const conn = try dns.helpers.connectToSystemResolver();
+    const conn = try dns.helpers.connectToSystemResolver(io);
     defer conn.close();
 
     logger.debug("selected nameserver: {f}", .{conn.address});
@@ -473,21 +435,20 @@ fn fetchTrustedAddresses(
 }
 
 // implementation taken from std.net address resolution
-fn lookupHosts(addrs: *std.array_list.Managed(std.net.Address), family: std.posix.sa_family_t, port: u16, name: []const u8) !void {
-    const file = std.fs.openFileAbsoluteZ("/etc/hosts", .{}) catch |err| switch (err) {
+fn lookupHosts(allocator: std.mem.Allocator, io: std.Io, addrs: *std.ArrayList(std.Io.net.IpAddress), port: u16, name: []const u8) !void {
+    const file = std.Io.Dir.openFileAbsolute(io, "/etc/hosts", .{}) catch |err| switch (err) {
         error.FileNotFound,
         error.NotDir,
         error.AccessDenied,
         => return,
         else => |e| return e,
     };
-    defer file.close();
+    defer file.close(io);
 
     var buffer: [4096]u8 = undefined;
-    var reader = file.reader(&buffer);
+    var reader = file.reader(io, &buffer);
     while (reader.interface.takeDelimiter('\n') catch |err| switch (err) {
         error.StreamTooLong => {
-            // line too long
             return error.StreamTooLong;
         },
         else => |e| return e,
@@ -505,131 +466,46 @@ fn lookupHosts(addrs: *std.array_list.Managed(std.net.Address), family: std.posi
             }
         } else continue;
 
-        const addr = std.net.Address.parseExpectingFamily(ip_text, family, port) catch |err| switch (err) {
-            error.Overflow,
-            error.InvalidEnd,
-            error.InvalidCharacter,
-            error.Incomplete,
-            error.InvalidIPAddressFormat,
-            error.InvalidIpv4Mapping,
-            error.NonCanonical,
-            => continue,
-        };
-        try addrs.append(addr);
+        const addr = std.Io.net.IpAddress.parse(ip_text, port) catch continue;
+        try addrs.append(allocator, addr);
     }
 }
 
 /// A getAddressList-like function that:
 ///  - gets a nameserver from resolv.conf
 ///  - starts a DNSConnection
-///  - extracts A/AAAA records and turns them into std.net.Address
+///  - extracts A/AAAA records and turns them into std.Io.net.IpAddress
 ///
-/// The only memory allocated here is for the list that holds std.net.Address.
-///
-/// This function does not implement the "happy eyeballs" algorithm.
-pub fn getAddressList(incoming_name: []const u8, port: u16, allocator: std.mem.Allocator) !AddressList {
+/// The only memory allocated here is for the list that holds IpAddress.
+pub fn getAddressList(io: std.Io, incoming_name: []const u8, port: u16, allocator: std.mem.Allocator) !AddressList {
     var name_buffer: [128][]const u8 = undefined;
     const name = try dns.Name.fromString(incoming_name, &name_buffer);
 
-    var final_list = std.array_list.Managed(std.net.Address).init(allocator);
-    defer final_list.deinit();
+    var final_list = std.ArrayList(std.Io.net.IpAddress).empty;
+    defer final_list.deinit(allocator);
 
     const last_label = name.full.labels[name.full.labels.len - 1];
 
     // see if we can short-circuit on parsing the name as addr
-    if (std.net.Address.parseExpectingFamily(incoming_name, std.posix.AF.INET, port) catch null) |addr| {
-        try final_list.append(addr);
-    } else if (std.net.Address.parseExpectingFamily(incoming_name, std.posix.AF.INET6, port) catch null) |addr| {
-        try final_list.append(addr);
+    if (std.Io.net.IpAddress.parse(incoming_name, port) catch null) |addr| {
+        try final_list.append(allocator, addr);
     } else if (std.mem.eql(u8, last_label, "localhost")) {
         // RFC 6761 Section 6.3.3
-        // Name resolution APIs and libraries SHOULD recognize localhost
-        // names as special and SHOULD always return the IP loopback address
-        // for address queries and negative responses for all other query
-        // types.
-        try final_list.append(std.net.Address.parseIp4("127.0.0.1", port) catch unreachable);
-        try final_list.append(std.net.Address.parseIp6("::1", port) catch unreachable);
+        try final_list.append(allocator, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = port } });
+        try final_list.append(allocator, .{ .ip6 = .{ .bytes = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, .port = port } });
     } else {
-        if (builtin.os.tag == .windows) {
-            const name_c = try allocator.dupeZ(u8, incoming_name);
-            defer allocator.free(name_c);
-
-            const port_c = try std.fmt.allocPrintZ(allocator, "{}", .{port});
-            defer allocator.free(port_c);
-
-            var addr_info: ?*ws2_32.addrinfoa = null;
-
-            const hints: ws2_32.addrinfo = .{
-                .flags = .{ .NUMERICSERV = true },
-                .family = ws2_32.AF.UNSPEC,
-                .socktype = ws2_32.SOCK.STREAM,
-                .protocol = ws2_32.IPPROTO.TCP,
-                .addr = null,
-                .canonname = null,
-                .addrlen = 0,
-                .next = null,
-            };
-
-            for (0..2) |_| {
-                const res = ws2_32.getaddrinfo(name_c.ptr, port_c.ptr, &hints, &addr_info);
-
-                if (res != 0) {
-                    switch (@as(ws2_32.WinsockError, @enumFromInt(res))) {
-                        .WSATRY_AGAIN => return error.TryAgain,
-                        .WSAEINVAL => return error.InvalidArgument,
-                        .WSANO_RECOVERY => return error.Fatal,
-                        .WSAEAFNOSUPPORT => return error.FamilyNotSupported,
-                        .WSA_NOT_ENOUGH_MEMORY => return error.NotEnoughMemory,
-                        .WSAHOST_NOT_FOUND => return error.HostNotFound,
-                        .WSATYPE_NOT_FOUND => return error.TypeNotFound,
-                        .WSAESOCKTNOSUPPORT => return error.SocketTypeNotSupported,
-                        .WSANOTINITIALISED => {
-                            try std.os.windows.callWSAStartup();
-                            continue;
-                        },
-                        else => return error.InternalUnexpected,
-                    }
-                } else break;
-            } else return error.InternalUnexpected;
-
-            defer ws2_32.freeaddrinfo(addr_info);
-
-            while (addr_info) |ai| : (addr_info = ai.next) {
-                switch (ai.family) {
-                    ws2_32.AF.INET => {
-                        const sa: *ws2_32.sockaddr.in = @as(
-                            *ws2_32.sockaddr.in,
-                            @ptrCast(@alignCast(ai.addr orelse continue)),
-                        );
-                        const addr = std.net.Address.initIp4(@as([4]u8, @bitCast(sa.addr)), sa.port);
-
-                        try final_list.append(addr);
-                    },
-                    ws2_32.AF.INET6 => {
-                        const sa: *ws2_32.sockaddr.in6 = @as(
-                            *ws2_32.sockaddr.in6,
-                            @ptrCast(@alignCast(ai.addr orelse continue)),
-                        );
-                        const addr = std.net.Address.initIp6(sa.addr, sa.port, 0, 0);
-
-                        try final_list.append(addr);
-                    },
-                    else => continue,
-                }
-            }
-        } else if (builtin.os.tag == .linux) {
-            try lookupHosts(&final_list, std.posix.AF.INET, port, incoming_name);
-            try lookupHosts(&final_list, std.posix.AF.INET, port, incoming_name);
+        if (builtin.os.tag == .linux or builtin.os.tag == .macos) {
+            try lookupHosts(allocator, io, &final_list, port, incoming_name);
 
             if (final_list.items.len == 0) {
                 // if that didn't work, go to dns server
-                const addrs_v4 = try fetchTrustedAddresses(allocator, name, .A);
+                const addrs_v4 = try fetchTrustedAddresses(allocator, io, name, .A);
                 defer allocator.free(addrs_v4);
-                for (addrs_v4) |addr| try final_list.append(addr);
+                for (addrs_v4) |addr| try final_list.append(allocator, addr);
 
-                const addrs_v6 = try fetchTrustedAddresses(allocator, name, .AAAA);
+                const addrs_v6 = try fetchTrustedAddresses(allocator, io, name, .AAAA);
                 defer allocator.free(addrs_v6);
-                for (addrs_v6) |addr| try final_list.append(addr);
+                for (addrs_v6) |addr| try final_list.append(allocator, addr);
             }
         } else @compileError("getAddressList not supported on this target");
     }
@@ -637,11 +513,11 @@ pub fn getAddressList(incoming_name: []const u8, port: u16, allocator: std.mem.A
     // RFC 6761 is not run if everything is v4 or only 1 address returned
     if (final_list.items.len == 1) return AddressList.fromList(allocator, &final_list);
     const all_ip4 = for (final_list.items) |addr| {
-        if (addr.any.family != std.posix.AF.INET) break false;
+        if (addr != .ip4) break false;
     } else true;
     if (all_ip4) return AddressList.fromList(allocator, &final_list);
 
-    std.mem.sort(std.net.Address, final_list.items, {}, addrCmpLessThan);
+    std.mem.sort(std.Io.net.IpAddress, final_list.items, {}, addrCmpLessThan);
 
     return AddressList.fromList(allocator, &final_list);
 }
@@ -660,13 +536,14 @@ const Policy = struct {
 const policy_table = [_]Policy{
     Policy.new(CidrRange.parse("::1/128") catch unreachable, 50, 0), // Loopback
     Policy.new(CidrRange.parse("::/0") catch unreachable, 40, 1), // Default
-    Policy.new(CidrRange.parse("::ffff:0:0/96") catch unreachable, 35, 4), // IPv4-mapped
+    Policy.new(CidrRange.parse("0:0:0:0:0:ffff:0:0/96") catch unreachable, 35, 4), // IPv4-mapped
     Policy.new(CidrRange.parse("2002::/16") catch unreachable, 30, 2), // 6to4
     Policy.new(CidrRange.parse("2001::/32") catch unreachable, 5, 5), // Teredo
     Policy.new(CidrRange.parse("fc00::/7") catch unreachable, 3, 13), // ULA
     Policy.new(CidrRange.parse("::/96") catch unreachable, 1, 3), // IPv4-compatible
 };
-fn cmpGetPrecedence(addr: std.net.Address) usize {
+
+fn cmpGetPrecedence(addr: std.Io.net.IpAddress) usize {
     for (policy_table) |policy| {
         if (policy.cidr.contains(addr) catch unreachable) {
             return policy.precedence;
@@ -675,28 +552,47 @@ fn cmpGetPrecedence(addr: std.net.Address) usize {
     return 40; // Default precedence if no match
 }
 
-fn isMulticast(a: std.net.Address) bool {
-    return a.in6.sa.addr[0] == 0xff;
+fn getIp6Bytes(addr: std.Io.net.IpAddress) [16]u8 {
+    return switch (addr) {
+        .ip4 => |ip4| blk: {
+            var result: [16]u8 = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0 };
+            result[12] = ip4.bytes[0];
+            result[13] = ip4.bytes[1];
+            result[14] = ip4.bytes[2];
+            result[15] = ip4.bytes[3];
+            break :blk result;
+        },
+        .ip6 => |ip6| ip6.bytes,
+    };
 }
 
-fn isLinklocal(a: std.net.Address) bool {
-    return a.in6.sa.addr[0] == 0xfe and (a.in6.sa.addr[1] & 0xc0) == 0x80;
+fn isMulticast(a: std.Io.net.IpAddress) bool {
+    const bytes = getIp6Bytes(a);
+    return bytes[0] == 0xff;
 }
 
-fn isLoopback(a: std.net.Address) bool {
-    return a.in6.sa.addr[0] == 0 and a.in6.sa.addr[1] == 0 and
-        a.in6.sa.addr[2] == 0 and
-        a.in6.sa.addr[12] == 0 and a.in6.sa.addr[13] == 0 and
-        a.in6.sa.addr[14] == 0 and a.in6.sa.addr[15] == 1;
+fn isLinklocal(a: std.Io.net.IpAddress) bool {
+    const bytes = getIp6Bytes(a);
+    return bytes[0] == 0xfe and (bytes[1] & 0xc0) == 0x80;
 }
 
-fn isSitelocal(a: std.net.Address) bool {
-    return a.in6.sa.addr[0] == 0xfe and (a.in6.sa.addr[1] & 0xc0) == 0xc0;
+fn isLoopback(a: std.Io.net.IpAddress) bool {
+    const bytes = getIp6Bytes(a);
+    return bytes[0] == 0 and bytes[1] == 0 and
+        bytes[2] == 0 and
+        bytes[12] == 0 and bytes[13] == 0 and
+        bytes[14] == 0 and bytes[15] == 1;
 }
 
-fn cmpGetScope(addr: std.net.Address) usize {
+fn isSitelocal(a: std.Io.net.IpAddress) bool {
+    const bytes = getIp6Bytes(a);
+    return bytes[0] == 0xfe and (bytes[1] & 0xc0) == 0xc0;
+}
+
+fn cmpGetScope(addr: std.Io.net.IpAddress) usize {
+    const bytes = getIp6Bytes(addr);
     if (isMulticast(addr)) {
-        return addr.in6.sa.addr[1] & 15;
+        return bytes[1] & 15;
     } else if (isLinklocal(addr)) {
         return 2;
     } else if (isLoopback(addr)) {
@@ -707,7 +603,7 @@ fn cmpGetScope(addr: std.net.Address) usize {
     return 14;
 }
 
-fn cmpAddresses(a: std.net.Address, b: std.net.Address) bool {
+fn cmpAddresses(a: std.Io.net.IpAddress, b: std.Io.net.IpAddress) bool {
     // RFC 6761. Rules 3, 4, and 7 are omitted.
 
     // Rule 6: Prefer higher precedence
@@ -730,7 +626,7 @@ fn cmpAddresses(a: std.net.Address, b: std.net.Address) bool {
     return false;
 }
 
-fn addrCmpLessThan(context: void, b: std.net.Address, a: std.net.Address) bool {
+fn addrCmpLessThan(context: void, b: std.Io.net.IpAddress, a: std.Io.net.IpAddress) bool {
     _ = context;
     return cmpAddresses(a, b);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,7 +13,7 @@ pub var current_log_level: std.log.Level = .info;
 
 fn logfn(
     comptime message_level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @TypeOf(.enum_literal),
     comptime format: []const u8,
     args: anytype,
 ) void {
@@ -22,28 +22,14 @@ fn logfn(
     }
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer {
-        _ = gpa.deinit();
-    }
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
 
-    if (builtin.os.tag == .windows) {
-        const debug = try std.unicode.utf8ToUtf16LeAllocZ(allocator, "DEBUG");
-        defer allocator.free(debug);
+    if (std.mem.eql(u8, init.environ_map.get("DEBUG") orelse "", "1")) current_log_level = .debug;
 
-        const debug_expected = try std.unicode.utf8ToUtf16LeAllocZ(allocator, "1");
-        defer allocator.free(debug_expected);
-
-        if (std.mem.eql(u16, std.process.getenvW(debug) orelse &[_]u16{0}, debug_expected)) current_log_level = .debug;
-    } else {
-        if (std.mem.eql(u8, std.posix.getenv("DEBUG") orelse "", "1")) current_log_level = .debug;
-    }
-
-    var args_it = try std.process.argsWithAllocator(allocator);
-    defer args_it.deinit();
-    _ = args_it.skip();
+    var args_it = init.minimal.args.iterate();
+    _ = args_it.next(); // skip program name
 
     const name_string = (args_it.next() orelse {
         logger.warn("no name provided", .{});
@@ -78,7 +64,7 @@ pub fn main() !void {
     // create question packet
     var packet = dns.Packet{
         .header = .{
-            .id = dns.helpers.randomHeaderId(),
+            .id = dns.helpers.randomHeaderId(io),
             .is_response = false,
             .wanted_recursion = true,
             .question_length = 1,
@@ -91,12 +77,12 @@ pub fn main() !void {
 
     logger.debug("packet: {any}", .{packet});
 
-    const conn = if (builtin.os.tag == .windows) try dns.helpers.connectToResolver("8.8.8.8", null) else try dns.helpers.connectToSystemResolver();
+    const conn = if (builtin.os.tag == .windows) try dns.helpers.connectToResolver(io, "8.8.8.8", null) else try dns.helpers.connectToSystemResolver(io);
     defer conn.close();
 
     logger.info("selected nameserver: {f}\n", .{conn.address});
     var stdout_buffer: [1024]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&stdout_buffer);
+    var stdout = std.Io.File.stdout().writer(io, &stdout_buffer);
 
     // print out our same question as a zone file for debugging purposes
     try dns.helpers.printAsZoneFile(&packet, undefined, &stdout.interface);

--- a/src/main_tinyhost.zig
+++ b/src/main_tinyhost.zig
@@ -11,7 +11,7 @@ pub var current_log_level: std.log.Level = .info;
 
 fn logfn(
     comptime message_level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @TypeOf(.enum_literal),
     comptime format: []const u8,
     args: anytype,
 ) void {
@@ -20,34 +20,25 @@ fn logfn(
     }
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer {
-        _ = gpa.deinit();
-    }
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
 
-    const debug = std.process.getEnvVarOwned(allocator, "DEBUG") catch |err| switch (err) {
-        error.EnvironmentVariableNotFound => try allocator.dupe(u8, ""),
-        else => return err,
-    };
-    defer allocator.free(debug);
-    if (std.mem.eql(u8, debug, "1")) current_log_level = .debug;
+    if (std.mem.eql(u8, init.environ_map.get("DEBUG") orelse "", "1")) current_log_level = .debug;
 
-    var args_it = try std.process.argsWithAllocator(allocator);
-    defer args_it.deinit();
-    _ = args_it.skip();
+    var args_it = init.minimal.args.iterate();
+    _ = args_it.next(); // skip program name
 
     const name_string = (args_it.next() orelse {
         logger.warn("no name provided", .{});
         return error.InvalidArgs;
     });
 
-    var addrs = try dns.helpers.getAddressList(name_string, 80, allocator);
+    var addrs = try dns.helpers.getAddressList(io, name_string, 80, allocator);
     defer addrs.deinit();
 
     var stdout_buffer: [1024]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&stdout_buffer);
+    var stdout = std.Io.File.stdout().writer(io, &stdout_buffer);
 
     for (addrs.addrs) |addr| {
         try stdout.interface.print("{s} has address {f}\n", .{ name_string, addr });

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -50,8 +50,8 @@ pub const ResourceDataHolder = struct {
 
     pub fn readAllAlloc(
         self: @This(),
-        allocator: std.mem.Allocator,
         reader: *std.Io.Reader,
+        allocator: std.mem.Allocator,
     ) !dns.ResourceData.Opaque {
         const opaque_rdata = try allocator.alloc(u8, self.size);
         const read_bytes = try reader.read(opaque_rdata);

--- a/src/resource_data.zig
+++ b/src/resource_data.zig
@@ -48,7 +48,7 @@ fn maybeReadResourceName(
 
 /// Common representations of DNS' Resource Data.
 pub const ResourceData = union(Type) {
-    A: std.net.Address,
+    A: std.Io.net.IpAddress,
 
     NS: ?dns.Name,
     MD: ?dns.Name,
@@ -82,7 +82,7 @@ pub const ResourceData = union(Type) {
     },
     MX: MXData,
     TXT: ?[]const u8,
-    AAAA: std.net.Address,
+    AAAA: std.Io.net.IpAddress,
     SRV: SRVData,
     OPT: void, // EDNS0 is not implemented
 
@@ -142,10 +142,9 @@ pub const ResourceData = union(Type) {
     pub fn writeTo(self: Self, writer: *std.Io.Writer) !void {
         return switch (self) {
             .A => |addr| {
-                try writer.writeInt(u32, addr.in.sa.addr, .big);
-                // break :blk @sizeOf(@TypeOf(addr.in.sa.addr));
+                _ = try writer.write(&addr.ip4.bytes);
             },
-            .AAAA => |addr| _ = try writer.write(&addr.in6.sa.addr),
+            .AAAA => |addr| _ = try writer.write(&addr.ip6.bytes),
 
             .NS, .MD, .MF, .MB, .MG, .MR, .CNAME, .PTR => |name| try name.?.writeTo(writer),
 
@@ -234,14 +233,14 @@ pub const ResourceData = union(Type) {
                 var ip4addr: [4]u8 = undefined;
                 try reader.readSliceAll(&ip4addr);
                 break :blk ResourceData{
-                    .A = std.net.Address.initIp4(ip4addr, 0),
+                    .A = .{ .ip4 = .{ .bytes = ip4addr, .port = 0 } },
                 };
             },
             .AAAA => blk: {
                 var ip6_addr: [16]u8 = undefined;
                 try reader.readSliceAll(&ip6_addr);
                 break :blk ResourceData{
-                    .AAAA = std.net.Address.initIp6(ip6_addr, 0, 0, 0),
+                    .AAAA = .{ .ip6 = .{ .bytes = ip6_addr, .port = 0 } },
                 };
             },
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -30,7 +30,11 @@ const TEST_PKT_RESPONSE = "RM2BgAABAAEAAAAABmdvb2dsZQNjb20AAAEAAcAMAAEAAQAAASwAB
 const GOOGLE_COM_LABELS = [_][]const u8{ "google"[0..], "com"[0..] };
 
 test "Packet serialize/deserialize" {
-    const random_id = dns.helpers.randomHeaderId();
+    var seed_buf: [8]u8 = undefined;
+    @memset(&seed_buf, 0x42); // deterministic for test
+    const seed = std.mem.readInt(u64, &seed_buf, .little);
+    var r = std.Random.DefaultPrng.init(seed);
+    const random_id = r.random().int(u16);
     const packet = dns.Packet{
         .header = .{ .id = random_id },
         .questions = &[_]dns.Question{},
@@ -138,7 +142,7 @@ test "deserialization of reply google.com/A" {
         @as(dns.ResourceType, resource_data),
     );
 
-    const addr = @as(*const [4]u8, @ptrCast(&resource_data.A.in.sa.addr)).*;
+    const addr = resource_data.A.ip4.bytes;
     try testing.expectEqual(@as(u8, 216), addr[0]);
     try testing.expectEqual(@as(u8, 58), addr[1]);
     try testing.expectEqual(@as(u8, 202), addr[2]);
@@ -251,7 +255,7 @@ test "rdata serialization" {
     var name_buffer: [2][]const u8 = undefined;
     const name = try dns.Name.fromString("google.com", &name_buffer);
     var resource_data = dns.ResourceData{
-        .A = try std.net.Address.parseIp4("127.0.0.1", 0),
+        .A = .{ .ip4 = .{ .bytes = .{ 1, 0, 0, 127 }, .port = 0 } },
     };
 
     var opaque_rdata_buffer: [1024]u8 = undefined;
@@ -291,10 +295,12 @@ test "rdata serialization" {
 }
 
 test "localhost always resolves to 127.0.0.1" {
-    const addrs = try helpers.getAddressList("localhost", 80, std.testing.allocator);
+    const addrs = try helpers.getAddressList(std.testing.io, "localhost", 80, std.testing.allocator);
     defer addrs.deinit();
-    try std.testing.expectEqual(16777343, addrs.addrs[1].in.sa.addr);
-    try std.testing.expectEqualStrings("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", &addrs.addrs[0].in6.sa.addr);
+    // First should be IPv6 loopback ::1
+    try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, &addrs.addrs[0].ip6.bytes);
+    // Second should be IPv4 loopback 127.0.0.1
+    try std.testing.expectEqualSlices(u8, &.{ 127, 0, 0, 1 }, &addrs.addrs[1].ip4.bytes);
 }
 
 test "NS records with cross-rdata pointer compression" {


### PR DESCRIPTION
Performed using opencode and claude opus 4.6 with a migrate skill from skillsmp.com.  Hand reviewed the git diff and fixed up a couple of things.
Resulting code has removed platform specific calls and now works on OSX.  Checking for bugs on linux.

- Juicy Main: main() now accepts std.process.Init for gpa, io, environ_map, args
- std.net removed: migrate Address -> std.Io.net.IpAddress, Stream -> Socket
- std.fs deprecated: migrate to std.Io.Dir / std.Io.File APIs
- Thread io through all networking helpers (connectToResolver, getAddressList, etc.)
- std.meta.intToEnum -> std.enums.fromInt
- @Type(.enum_literal) -> @TypeOf(.enum_literal)
- std.time.nanoTimestamp removed: seed RNG via io.random()
- std.heap.GeneralPurposeAllocator removed: use init.gpa
- std.process.getEnvVarOwned removed: use init.environ_map
- build.zig: linkLibC() -> link_libc field on createModule
- build.zig.zon: minimum_zig_version bumped to 0.16.0
- test.zig: use std.testing.io for localhost resolution test